### PR TITLE
ローディングアニメーションを初回のみ表示する

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div id="loading">
+    <div id="loading" style="display:none;">
       <div class="loader">
         <img
           src="@/assets/images/grow-together.png"
@@ -59,34 +59,47 @@ export default {
     Footer,
     Project,
   },
-  mounted: function () {
+
+  mounted: function() {
+    const keyName = "visited";
+    const keyValue = true;
     let spinner = document.querySelector(".loader");
 
-    spinner.addEventListener("animationend", function () {
+    if (!localStorage.getItem(keyName)) {
+      document.getElementById("loading").removeAttribute("style");
+      localStorage.setItem(keyName, keyValue);
+      console.log("初めての訪問です");
+    } else {
+      console.log("訪問済みです");
+    }
+
+    spinner.addEventListener("animationend", function() {
       document.getElementById("loading").classList.add("loaded");
     });
   },
-function () {
-$(document).ready(function()
-{
-$('a[href^=#]').click(function()
-{
-var speed = 400;// ミリ秒
 
-var href= $(this).attr("href");
+  function() {
+    $(document).ready(function() {
+      $("a[href^=#]").click(function() {
+        var speed = 400; // ミリ秒
 
-var target = $(href == "#" || href == "" ? 'html' : href);
+        var href = $(this).attr("href");
 
-var position = target.offset().top;
+        var target = $(href == "#" || href == "" ? "html" : href);
 
-$($.support.safari ? 'body' : 'html').animate({scrollTop:position}, speed, 'swing');
+        var position = target.offset().top;
 
-return false;
-});
-});
-},
+        $($.support.safari ? "body" : "html").animate(
+          { scrollTop: position },
+          speed,
+          "swing"
+        );
 
-}
+        return false;
+      });
+    });
+  },
+};
 </script>
 
 <style>


### PR DESCRIPTION
## 概要
本プルリクエストには、ローディングアニメーションを初回のみ表示する編集が含まれています。

## 背景
以下、Slackより抜粋

> TOPページのローディングアニメーションを初回だけ表示したいです。
こちらもお力添えいただきたいです:大泣き:
【JavaScript】初回読み込み（アクセス）時にのみ処理を実行する｜Into the Program
https://into-the-program.com/execution-firsttime-access/

## 実装内容
初回アクセス時に、LocalStrageにそのログを記録。そのログが残っている限りはアニメーションは表示されない。


### 追記コード
TOPに以下のJSロジックを追記

```js
    const keyName = "visited";
    const keyValue = true;
    let spinner = document.querySelector(".loader");
    if (!localStorage.getItem(keyName)) {
      document.getElementById("loading").removeAttribute("style");
      localStorage.setItem(keyName, keyValue);
      console.log("初めての訪問です");
    } else {
      console.log("訪問済みです");
    }
```

また、id='loading'に`display:none` を付与

```css
<div id="loading" style="display:none;">
```


## 確認方法
以下の画像のように、検証ツールのApplicationタグからLocalStrageのログを削除することで、ローディングアニメーションのタイミングを確認できます。

<img width="1165" alt="スクリーンショット 2021-09-12 17 22 05" src="https://user-images.githubusercontent.com/44918658/132979432-dd049fc8-f617-49bf-90b8-4203db231287.png">
